### PR TITLE
Fixed Multiplayer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RimHUD
-![Mod Version](https://img.shields.io/badge/Mod_Version-1.14.4-blue.svg)
+![Mod Version](https://img.shields.io/badge/Mod_Version-1.14.5-blue.svg)
 ![RimWorld Version](https://img.shields.io/badge/Built_for_RimWorld-1.4-blue.svg)
 ![Harmony Version](https://img.shields.io/badge/Powered_by_Harmony-2.2.2-blue.svg)\
 ![Steam Downloads](https://img.shields.io/steam/downloads/1508850027?colorB=blue&label=Steam+Downloads)

--- a/source/Access/Patch/RimWorld_InspectPaneUtility_PaneSizeFor.cs
+++ b/source/Access/Patch/RimWorld_InspectPaneUtility_PaneSizeFor.cs
@@ -10,9 +10,9 @@ namespace RimHUD.Access.Patch
   [HarmonyPatch(typeof(InspectPaneUtility), "PaneSizeFor")]
   public static class RimWorld_InspectPaneUtility_PaneSizeFor
   {
-    private static bool Prefix(ref Vector2 __result, IInspectPane pane)
+    private static bool Prefix(ref Vector2 __result, IInspectPane? pane)
     {
-      if (!State.ModifyPane) { return true; }
+      if (!State.ModifyPane || pane is null) { return true; }
 
       __result = new Vector2(InspectPaneUtility.PaneWidthFor(pane), Theme.InspectPaneHeight.Value - WidgetsPlus.MainButtonHeight);
 

--- a/source/Access/Patch/RimWorld_InspectPaneUtility_PaneWidthFor.cs
+++ b/source/Access/Patch/RimWorld_InspectPaneUtility_PaneWidthFor.cs
@@ -10,11 +10,11 @@ namespace RimHUD.Access.Patch
   [HarmonyPatch(typeof(InspectPaneUtility), "PaneWidthFor")]
   public static class RimWorld_InspectPaneUtility_PaneWidthFor
   {
-    private static bool Prefix(ref float __result, IInspectPane pane)
+    private static bool Prefix(ref float __result, IInspectPane? pane)
     {
-      if (!State.ModifyPane) { return true; }
+      if (!State.ModifyPane || pane is null) { return true; }
 
-      __result = Theme.InspectPaneTabWidth.Value * (float)Mathf.Max(Theme.InspectPaneMinTabs.Value, pane.CurTabs.Count(static tab => tab.IsVisible && !tab.Hidden));
+      __result = Theme.InspectPaneTabWidth.Value * Mathf.Max(Theme.InspectPaneMinTabs.Value, pane.CurTabs?.Count(static tab => tab.IsVisible && !tab.Hidden) ?? 0f);
 
       return false;
     }

--- a/source/Engine/Report.cs
+++ b/source/Engine/Report.cs
@@ -63,7 +63,7 @@ namespace RimHUD.Engine
       public ErrorInfo(Exception exception)
       {
         var baseException = exception.GetBaseException();
-        Message = exception.Message + (exception == baseException ? null : $"\n{baseException.Message.Size(12)}");
+        Message = exception.Message + (exception == baseException ? null : $"\n{baseException.Message}");
 
         var isResetOnly = false;
 

--- a/source/External/CustomBarDef.cs
+++ b/source/External/CustomBarDef.cs
@@ -18,7 +18,7 @@ namespace RimHUD
     [Unsaved]
     private ExternalMethodHandler<(string? label, string? value, float fill, float[]? thresholds, Func<string?>? tooltip, Action? onHover, Action? onClick)>? _getParameters;
 
-    public IWidget Build(HudArgs _)
+    public IWidget Build(HudArgs? args)
     {
       var parameters = _getParameters?.Invoke(Active.Pawn) ?? throw new Exception($"Error getting {nameof(CustomBarDef)} parameters.").AddData(resetOnly: true);
       return new BarWidget(parameters.label, parameters.value, parameters.fill, parameters.thresholds, parameters.tooltip, parameters.onHover, parameters.onClick, textStyle.GetActual(), colorStyle);

--- a/source/External/CustomNeedDef.cs
+++ b/source/External/CustomNeedDef.cs
@@ -19,7 +19,7 @@ namespace RimHUD
 
     private Func<string?> GetTooltip => () => _getTooltip?.Invoke(Active.Pawn);
 
-    public IWidget? Build(HudArgs args) => new NeedBar(needDef!, GetTooltip, colorStyle).Build(args);
+    public IWidget? Build(HudArgs? args) => new NeedBar(needDef!, GetTooltip, colorStyle).Build(args);
 
     protected override void InitializeV1()
     {

--- a/source/External/CustomSelectorDef.cs
+++ b/source/External/CustomSelectorDef.cs
@@ -17,7 +17,7 @@ namespace RimHUD
     [Unsaved]
     private ExternalMethodHandler<(string? label, Func<string?>? tooltip, Action? onClick, Action? onHover, Color? backColor)>? _getParameters;
 
-    public IWidget Build(HudArgs _)
+    public IWidget Build(HudArgs? args)
     {
       var parameters = _getParameters?.Invoke(Active.Pawn) ?? throw new Exception($"Error getting {nameof(CustomSelectorDef)} parameters.").AddData(resetOnly: true);
       return new SelectorWidget(parameters.label, parameters.tooltip, parameters.onHover, parameters.onClick, textStyle.GetActual(), parameters.backColor);

--- a/source/External/CustomValueDef.cs
+++ b/source/External/CustomValueDef.cs
@@ -16,7 +16,7 @@ namespace RimHUD
     [Unsaved]
     private ExternalMethodHandler<(string? label, string? value, Func<string?>? tooltip, Action? onHover, Action? onClick)>? _getParameters;
 
-    public IWidget Build(HudArgs _)
+    public IWidget Build(HudArgs? args)
     {
       var parameters = _getParameters?.Invoke(Active.Pawn) ?? throw new Exception($"Error getting {nameof(CustomValueDef)} parameters.").AddData(resetOnly: true);
       return new ValueWidget(parameters.value is null ? null : parameters.label, parameters.value ?? parameters.label, parameters.tooltip, parameters.onHover, parameters.onClick, textStyle.GetActual());

--- a/source/Integration/Multiplayer/Mod_Multiplayer.cs
+++ b/source/Integration/Multiplayer/Mod_Multiplayer.cs
@@ -1,4 +1,5 @@
 using System;
+using HarmonyLib;
 using RimHUD.Engine;
 using RimWorld;
 using Verse;
@@ -13,8 +14,8 @@ namespace RimHUD.Integration.Multiplayer
       {
         if (!Traverse.Field("enabled")!.GetValue<bool>()) { return; }
 
-        var registerSyncMethod = Traverse.Method("RegisterSyncMethod");
-        if (registerSyncMethod is null) { throw new Exception("Failed to find RegisterSyncMethod."); }
+        var registerSyncMethod = Traverse.Method("RegisterSyncMethod", new[] { typeof(Type), typeof(string), AccessTools.TypeByName("Multiplayer.API.SyncType").MakeArrayType() });
+        if (registerSyncMethod is null || !registerSyncMethod.MethodExists()) { throw new Exception("Failed to find RegisterSyncMethod."); }
 
         registerSyncMethod.GetValue(typeof(Mod_Multiplayer), nameof(SetSelfTend), null);
 

--- a/source/Interface/Hud/HudWidget.cs
+++ b/source/Interface/Hud/HudWidget.cs
@@ -17,7 +17,7 @@ namespace RimHUD.Interface.Hud
     public string Id { get; }
     public Def? Def { get; }
 
-    public Type? DefType { get; }
+    private readonly Type? _defType;
 
     private readonly BuilderDelegate _builder;
     public LayoutElement LayoutElement { get; }
@@ -30,7 +30,7 @@ namespace RimHUD.Interface.Hud
       _builder = builder;
 
       Def = def;
-      DefType = defType;
+      _defType = defType;
 
       LayoutElement = new LayoutElement(LayoutElementType.Widget, Id, Def);
     }
@@ -59,12 +59,12 @@ namespace RimHUD.Interface.Hud
 
     public bool DefNameIsValid(string? defName)
     {
-      if (DefType is null) { return true; }
+      if (_defType is null) { return true; }
       if (defName is null) { return false; }
 
       if (_validDefNames.TryGetValue(defName, out var value)) { return value; }
 
-      var def = GenDefDatabase.GetDef(DefType, defName, false);
+      var def = GenDefDatabase.GetDef(_defType, defName, false);
       return _validDefNames[defName] = def is not null && (def is not ExternalWidgetDef externalWidgetDef || externalWidgetDef.Initialized);
     }
   }

--- a/source/Interface/Hud/Models/BarModel.cs
+++ b/source/Interface/Hud/Models/BarModel.cs
@@ -10,6 +10,6 @@ namespace RimHUD.Interface.Hud.Models
     protected virtual float[]? Thresholds => null;
     protected virtual BarColorStyle? ColorStyle => null;
 
-    public override IWidget? Build(HudArgs args) => Fill < 0f ? null : new BarWidget(Label, Value, Fill, Thresholds, Tooltip, OnHover, OnClick, TextStyle, args.BarColorStyle ?? ColorStyle ?? default);
+    public override IWidget? Build(HudArgs? args) => Fill < 0f ? null : new BarWidget(Label, Value, Fill, Thresholds, Tooltip, OnHover, OnClick, TextStyle, args?.BarColorStyle ?? ColorStyle ?? default);
   }
 }

--- a/source/Interface/Hud/Models/BaseModel.cs
+++ b/source/Interface/Hud/Models/BaseModel.cs
@@ -7,7 +7,8 @@ namespace RimHUD.Interface.Hud.Models
 {
   public abstract class BaseModel : IModel
   {
-    public abstract IWidget? Build(HudArgs args);
+    public abstract IWidget? Build(HudArgs? args);
+
     protected virtual string? Label => null;
     protected virtual Func<string?>? Tooltip => null;
 

--- a/source/Interface/Hud/Models/IModel.cs
+++ b/source/Interface/Hud/Models/IModel.cs
@@ -4,6 +4,6 @@ namespace RimHUD.Interface.Hud.Models
 {
   public interface IModel
   {
-    IWidget? Build(HudArgs args);
+    IWidget? Build(HudArgs? args);
   }
 }

--- a/source/Interface/Hud/Models/SelectorModel.cs
+++ b/source/Interface/Hud/Models/SelectorModel.cs
@@ -10,6 +10,6 @@ namespace RimHUD.Interface.Hud.Models
     protected override TextStyle TextStyle => Theme.SmallTextStyle;
     protected virtual Color? Color => null;
 
-    public override IWidget? Build(HudArgs args) => OnClick is null ? null : new SelectorWidget(Label, Tooltip, OnClick, OnHover, TextStyle, Color);
+    public override IWidget? Build(HudArgs? args) => OnClick is null ? null : new SelectorWidget(Label, Tooltip, OnClick, OnHover, TextStyle, Color);
   }
 }

--- a/source/Interface/Hud/Models/ValueModel.cs
+++ b/source/Interface/Hud/Models/ValueModel.cs
@@ -6,6 +6,6 @@ namespace RimHUD.Interface.Hud.Models
   {
     protected abstract string? Value { get; }
 
-    public override IWidget? Build(HudArgs args) => Value is null ? null : new ValueWidget(Label, Value, Tooltip, OnHover, OnClick, TextStyle);
+    public override IWidget? Build(HudArgs? args) => Value is null ? null : new ValueWidget(Label, Value, Tooltip, OnHover, OnClick, TextStyle);
   }
 }

--- a/source/Interface/Screen/InspectPaneButtons.cs
+++ b/source/Interface/Screen/InspectPaneButtons.cs
@@ -47,9 +47,9 @@ namespace RimHUD.Interface.Screen
       if (AllowResponse(pawn)) { HostilityResponseModeUtility.DrawResponseButton(GetRowRect(bounds, ref offset), pawn, false); }
 
       if (AllowMedical(pawn)) { DrawMedical(pawn, GetRowRect(bounds, ref offset)); }
-      if (AllowRename(pawn)) { TrainingCardUtility.DrawRenameButton(GetRowRect(bounds, ref offset, GenUI.SmallIconSize + GUIPlus.SmallPadding, GenUI.SmallIconSize + GUIPlus.SmallPadding), pawn); }
-
       if (AllowSelfTend(pawn)) { DrawSelfTend(pawn, GetRowRect(bounds, ref offset)); }
+
+      if (AllowRename(pawn)) { TrainingCardUtility.DrawRenameButton(GetRowRect(bounds, ref offset, GenUI.SmallIconSize + GUIPlus.SmallPadding, GenUI.SmallIconSize + GUIPlus.SmallPadding), pawn); }
     }
 
     private static Rect GetRowRect(Rect bounds, ref float offset, float width = GenUI.SmallIconSize, float height = GenUI.SmallIconSize)
@@ -118,7 +118,7 @@ namespace RimHUD.Interface.Screen
     private static bool AllowIdeo(Pawn pawn) => Theme.ShowIdeoligionIcon.Value && ModsConfig.IdeologyActive && pawn.Ideo is not null;
     private static bool AllowResponse(Pawn pawn) => pawn.playerSettings!.UsesConfigurableHostilityResponse;
     private static bool AllowMedical(Pawn pawn) => pawn.RaceProps?.IsFlesh ?? false;
-    private static bool AllowRename(Pawn pawn) => !AllowMedical(pawn);
     private static bool AllowSelfTend(Pawn pawn) => pawn.IsColonist;
+    private static bool AllowRename(Pawn pawn) => (pawn.Faction == Faction.OfPlayer && (pawn.RaceProps?.Animal ?? false) && pawn.RaceProps.hideTrainingTab) || (ModsConfig.BiotechActive && pawn.IsColonyMech);
   }
 }

--- a/source/Mod.cs
+++ b/source/Mod.cs
@@ -13,7 +13,7 @@ namespace RimHUD
   {
     public const string Id = "RimHUD";
     public const string Name = Id;
-    public const string Version = "1.14.4";
+    public const string Version = "1.14.5";
 
     public const string WorkshopLink = "https://steamcommunity.com/sharedfiles/filedetails/?id=1508850027";
 


### PR DESCRIPTION
It seems that the Multiplayer integration has broken due to Traverse no longer being able to find the method. This happens due to an ambiguous match, as 2 methods share the same name. Considering that it seems Multiplayer added both of the methods at the same time, it's likely that Traverse stopped handling ambiguous matches like those to prevent potential issues.

The fix for the issue was fairly simple by providing the method argument types, so the correct method could be retrieved by Traverse. After some testing everything seems to work.

On top of fixing the issue, I've added additional check to see if the method was found by calling `.MethodExists()` (which is just a null check done by Traverse).